### PR TITLE
Add example to docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ information.
 
 On non-Windows platforms, `enable_ansi_support` is a no-op.
 
+## Example
+
+```rust
+fn main() {
+    enable_ansi_support::enable_ansi_support();
+
+    // use your terminal color library of choice here
+}
+```
+
 ## Minimum supported Rust version
 
 The minimum supported Rust version (MSRV) is **1.41**. Unless there's a compelling reason to update it, it is most

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,18 +11,39 @@
 //! [`ansi_term`](https://docs.rs/ansi_term) or [`owo-colors`](https://docs.rs/owo-colors)
 //! to work on Windows just like they do on Unix platforms.
 //!
+//! ## Example
+//!
+//! ```
+//! fn main() {
+//!     enable_ansi_support::enable_ansi_support();
+//!
+//!     // use your terminal color library of choice here
+//! }
+//! ```
+//!
+//! ## More Info
+//!
 //! This uses Windows API calls to alter the properties of the console that
 //! the program is running in. See the
 //! [Windows documentation](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences)
 //! for more information.
 //!
 //! On non-Windows platforms, `enable_ansi_support` is a no-op.
+#![allow(clippy::needless_doctest_main)]
 
 /// Enables ANSI code support on Windows 10.
 ///
 /// Returns the Windows error code if unsuccessful.
 ///
 /// On non-Windows platforms, this is a no-op that always returns `Ok(())`.
+///
+/// ## Example
+///
+/// ```
+/// fn main() {
+///     enable_ansi_support::enable_ansi_support();
+/// }
+/// ```
 #[cfg(windows)]
 pub fn enable_ansi_support() -> Result<(), u32> {
     // ref: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#EXAMPLE_OF_ENABLING_VIRTUAL_TERMINAL_PROCESSING @@ https://archive.is/L7wRJ#76%
@@ -82,6 +103,14 @@ pub fn enable_ansi_support() -> Result<(), u32> {
 /// Returns the Windows error code if unsuccessful.
 ///
 /// On non-Windows platforms, this is a no-op that always returns `Ok(())`.
+///
+/// ## Example
+///
+/// ```
+/// fn main() {
+///     enable_ansi_support::enable_ansi_support();
+/// }
+/// ```
 #[cfg(not(windows))]
 #[inline]
 pub fn enable_ansi_support() -> Result<(), u32> {


### PR DESCRIPTION
Really small change, but the motivation here being that it's a lot easier to skim with an example.

maybe just a personal preference but even though its simple this sentence:

![image](https://user-images.githubusercontent.com/8260240/144883623-357d908f-eda9-41e4-8818-bae0dfb54972.png)

takes a lot longer to visually parse and digest than this example:

![image](https://user-images.githubusercontent.com/8260240/144883671-4defa2bb-5074-4446-b2e1-393a3c16d01e.png)

([Rendered changes here](https://github.com/jam1garner/enable-ansi-support/blob/docs-example/README.md))

(And since I didn't make an issue first, feel free to just close the PR if you're not a fan of the changes, no hard feelings or explanation needed if so ^^)