### PR TITLE
Switch to windows-sys crate, update MSRV to 1.49, add keywords and categories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Reference:
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ name: CI
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # Typically one would use ubuntu-latest for clippy and rustfmt jobs. Use windows-latest in this
+    # case because most of the code is Windows-specific.
+    runs-on: windows-latest
     env:
       RUSTFLAGS: -D warnings
     steps:
@@ -19,6 +21,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Lint (rustfmt)
         run: cargo xfmt --check
       - name: Lint (clippy)
@@ -30,8 +33,8 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        # 1.41 is the MSRV
-        rust-version: [ 1.41, stable ]
+        # 1.49 is the MSRV
+        rust-version: [ 1.49, stable ]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings
@@ -41,6 +44,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust-version }}
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,14 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          # By default actions/checkout checks out a merge commit. Prefer the PR tip instead.
-          # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
           components: rustfmt, clippy
       - name: Lint (rustfmt)
-        uses: actions-rs/cargo@v1
-        with:
-          command: xfmt
-          args: --check
+        run: cargo xfmt --check
       - name: Lint (clippy)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets
+        run: cargo clippy --all-features --all-targets
 
   build:
     name: Build and test
@@ -47,20 +36,12 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-version }}
-          override: true
-
+          components: rustfmt, clippy
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,10 @@ jobs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build rustdoc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          # cargo-compare currently pulls in cargo which bloats build times massively
-          args: --all-features
+        run: cargo doc --all-features
       - name: Organize
         run: |
           mkdir target/gh-pages
@@ -31,3 +25,4 @@ jobs:
         with:
           branch: gh-pages
           folder: target/gh-pages
+          single-commit: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Build rustdoc
         run: cargo doc --all-features
       - name: Organize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,11 @@ jobs:
     if: github.repository_owner == 'sunshowers-code'
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.2.0] - 2022-12-10
+
+### Changed
+
+- `enable_ansi_support` now returns `std::io::Error` rather than the raw Win32 error code.
+- Internal implementation now uses the windows-sys crate.
+- MSRV updated to Rust 1.49, and new MSRV policy defined: updates will be considered a breaking
+  change.
+
 ## [0.1.2] - 2022-01-19
 
 - Update links to new repository location.
@@ -16,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 - Initial release.
 
+[0.2.0]: https://github.com/sunshowers-code/enable-ansi-support/releases/tag/0.2.0
 [0.1.2]: https://github.com/sunshowers-code/enable-ansi-support/releases/tag/0.1.2
 [0.1.1]: https://github.com/sunshowers-code/enable-ansi-support/releases/tag/0.1.1
 [0.1.0]: https://github.com/sunshowers-code/enable-ansi-support/releases/tag/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,21 @@ edition = "2018"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/sunshowers-code/enable-ansi-support"
+rust-version = "1.49"
+keywords = [
+    "ansi",
+    "windows",
+    "console",
+    "terminal",
+    "color",
+    "enable-ansi-support",
+]
+categories = ["command-line-interface", "os::windows-apis"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "winnt"] }
+windows-sys = { version = "0.42.0", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_Console",
+] }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ fn main() {
     match enable_ansi_support::enable_ansi_support() {
         Ok(()) => {
             // ANSI escape codes were successfully enabled, or this is a non-Windows platform.
+            // Use your terminal color library of choice here.
+            println!("\x1b[31mHello, world\x1b[0m");
         }
         Err(_) => {
             // The operation was unsuccessful, typically because it's running on an older
@@ -29,14 +31,13 @@ fn main() {
             // this case.
         }
     }
-    // Use your terminal color library of choice here.
 }
 ```
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) is **1.41**. Unless there's a compelling reason to update it, it is most
-likely going to stay at 1.41 forever.
+The minimum supported Rust version (MSRV) is **1.49**. The MSRV will be updated sparingly, and any
+update to it will be considered a breaking change.
 
 ## License and credits
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The enable-ansi-support Contributors
+// SPDX-License-Identifier: MIT
+
+#[test]
+fn test_basic() {
+    let res = enable_ansi_support::enable_ansi_support();
+    println!("enable_ansi_support status: {:?}", res);
+    if res.is_ok() {
+        println!("\x1b[31mHello, world\x1b[0m");
+    }
+}


### PR DESCRIPTION
This will be a breaking change since the return value is now `std::io::Error`. Also I think for a crate like this, an MSRV change is a breaking one.