### PR TITLE
Update windows-sys to 0.61.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        # 1.49 is the MSRV
-        rust-version: [ 1.49, stable ]
+        # 1.71 is the MSRV
+        rust-version: [ 1.71, stable ]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.3.0] - upcoming
+
+- `windows-sys` dependency updated to version `0.61.0`
+- MSRV updated to Rust 1.71
+
 ## [0.2.1] - 2022-12-10
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/sunshowers-code/enable-ansi-support"
-rust-version = "1.49"
+rust-version = "1.71"
 keywords = ["ansi", "windows", "console", "terminal", "color"]
 categories = ["command-line-interface", "os::windows-apis"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = [
+windows-sys = { version = "0.61.0", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_Security",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fn main() {
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) is **1.49**. The MSRV will be updated sparingly, and any
+The minimum supported Rust version (MSRV) is **1.71**. The MSRV will be updated sparingly, and any
 update to it will be considered a breaking change.
 
 ## License and credits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub fn enable_ansi_support() -> Result<(), std::io::Error> {
             std::ptr::null(),
             OPEN_EXISTING,
             0,
-            0,
+            std::ptr::null_mut(),
         );
         if console_handle == INVALID_HANDLE_VALUE {
             return Err(std::io::Error::last_os_error());


### PR DESCRIPTION
This would allow removing `windows-sys 0.42.0` from `nextest` dependencies.